### PR TITLE
Query calls Fields.Build if the Fields implements Builder interface for JOIN

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -34,3 +34,11 @@ func NewBuilder(fn BuildFunc) Builder { // nolint:ireturn
 func (b *buildFuncWrapper) Build(st *statement.Statement) {
 	b.fn(st)
 }
+
+type BuildFuncs []BuildFunc
+
+func (s BuildFuncs) Build(st *statement.Statement) {
+	for _, fn := range s {
+		fn(st)
+	}
+}

--- a/fields.go
+++ b/fields.go
@@ -9,8 +9,10 @@ type Fields[M any] struct {
 	buildFuncs BuildFuncs
 }
 
-var _ FieldMapper[any] = (*Fields[any])(nil)
-var _ Builder = (*Fields[any])(nil)
+var (
+	_ FieldMapper[any] = (*Fields[any])(nil)
+	_ Builder          = (*Fields[any])(nil)
+)
 
 // NewFields creates a new Fields instance with the specified column names and mapper function.
 func NewFields[M any](names []string, scan Mapper[M], buildFunc ...BuildFunc) *Fields[M] {

--- a/fields.go
+++ b/fields.go
@@ -1,16 +1,20 @@
 package querybm
 
+import "github.com/tecowl/querybm/statement"
+
 // Fields implements FieldMapper with a static list of column names.
 type Fields[M any] struct {
-	names  []string
-	mapper Mapper[M]
+	names      []string
+	mapper     Mapper[M]
+	buildFuncs BuildFuncs
 }
 
 var _ FieldMapper[any] = (*Fields[any])(nil)
+var _ Builder = (*Fields[any])(nil)
 
 // NewFields creates a new Fields instance with the specified column names and mapper function.
-func NewFields[M any](names []string, scan Mapper[M]) *Fields[M] {
-	return &Fields[M]{names: names, mapper: scan}
+func NewFields[M any](names []string, scan Mapper[M], buildFunc ...BuildFunc) *Fields[M] {
+	return &Fields[M]{names: names, mapper: scan, buildFuncs: buildFunc}
 }
 
 // Fields returns the column names for the static columns.
@@ -21,4 +25,8 @@ func (c *Fields[M]) Fields() []string {
 // Mapper returns the mapper function for the static columns.
 func (c *Fields[M]) Mapper() Mapper[M] {
 	return c.mapper
+}
+
+func (c *Fields[M]) Build(st *statement.Statement) {
+	c.buildFuncs.Build(st)
 }

--- a/query.go
+++ b/query.go
@@ -71,6 +71,9 @@ func (q *Query[M]) BuildCountSelect() (string, []any) {
 // It returns the SQL query string and its arguments.
 func (q *Query[M]) BuildRowsSelect() (string, []any) {
 	st := statement.New(q.Table, q.Fields)
+	if fb, ok := q.Fields.(Builder); ok {
+		fb.Build(st)
+	}
 	q.Condition.Build(st)
 	q.Sort.Build(st)
 	q.Pagination.Build(st)

--- a/statement/statement.go
+++ b/statement/statement.go
@@ -34,8 +34,14 @@ func New(table string, fields Fields) *Statement {
 
 // Build constructs the complete SQL query string and returns it along with the placeholder values.
 func (s *Statement) Build() (string, []any) {
-	queryParts := []string{"SELECT", strings.Join(s.Fields.Fields(), ", "), "FROM", s.Table.content}
+	queryParts := []string{"SELECT", strings.Join(s.Fields.Fields(), ", ")}
 	args := make([]any, 0)
+
+	{
+		s, values := s.Table.Build()
+		queryParts = append(queryParts, "FROM", s)
+		args = append(args, values...)
+	}
 
 	if !s.Where.IsEmpty() {
 		content, values := s.Where.Build()

--- a/statement/statement_test.go
+++ b/statement/statement_test.go
@@ -12,9 +12,19 @@ func TestNewStatement(t *testing.T) {
 	fields := NewSimpleFields("id", "name", "email")
 	s := New("users", fields)
 
-	if s.Table.content != "users" {
-		t.Errorf("NewStatement() table = %v, want %v", s.Table.content, "users")
+	if s.Table == nil {
+		t.Errorf("NewStatement() Table should not be nil")
 	}
+	{
+		r, args := s.Table.Build()
+		if r != "users" {
+			t.Errorf("NewStatement() Table content = %v, want %v", r, "users")
+		}
+		if len(args) != 0 {
+			t.Errorf("NewStatement() Table values = %v, want empty slice", args)
+		}
+	}
+
 	if !reflect.DeepEqual(s.Fields, fields) {
 		t.Errorf("NewStatement() fields = %v, want %v", s.Fields, fields)
 	}

--- a/statement/table.go
+++ b/statement/table.go
@@ -1,28 +1,142 @@
 package statement
 
+import (
+	"strings"
+
+	"github.com/tecowl/querybm/helpers/slices"
+)
+
+type tableName struct {
+	Name  string
+	Alias string
+	useAs bool // Indicates if the alias is used with "AS"
+}
+
+func parseTableName(s string) *tableName {
+	// Split into at most 3 parts: name, "AS", alias
+	parts := strings.SplitN(strings.TrimSpace(s), " ", 3) //nolint:mnd
+	switch len(parts) {
+	case 1:
+		return &tableName{Name: parts[0], Alias: "", useAs: false}
+	case 2: //nolint:mnd
+		return &tableName{Name: parts[0], Alias: parts[1], useAs: false}
+	default:
+		if strings.ToUpper(parts[1]) == "AS" {
+			// If the second part is "AS", treat it as an alias
+			return &tableName{Name: parts[0], Alias: parts[2], useAs: true}
+		}
+		return &tableName{Name: parts[0], Alias: strings.Join(parts[1:], " "), useAs: false}
+	}
+}
+
+func (t *tableName) String() string {
+	if t.Alias != "" {
+		if t.useAs {
+			return t.Name + " AS " + t.Alias
+		}
+		return t.Name + " " + t.Alias
+	}
+	return t.Name
+}
+
+func (t *tableName) AliasOrName() string {
+	if t.Alias != "" {
+		return t.Alias
+	}
+	return t.Name
+}
+
+func (t *tableName) MatchAliasOrName(s string) bool {
+	if t.Alias != "" {
+		return strings.EqualFold(t.Alias, s)
+	}
+	return strings.EqualFold(t.Name, s)
+}
+
+type joinItem struct {
+	tableName
+	joinType  string
+	Condition string
+	Args      []any
+}
+
+func (j *joinItem) Build() (string, []any) {
+	r := j.joinType + " " + j.tableName.String()
+	if j.Condition != "" {
+		r += " ON " + j.Condition
+	}
+	return r, j.Args
+}
+
+type joinItems []*joinItem
+
+func (s joinItems) Build() (string, []any) {
+	var sb strings.Builder
+	var args []any
+	for i, item := range s {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+		part, partArgs := item.Build()
+		sb.WriteString(part)
+		args = append(args, partArgs...)
+	}
+	return sb.String(), args
+}
+
+func (s joinItems) MatchAliasOrName(v string) bool {
+	return slices.Any(s, func(item *joinItem) bool {
+		return item.MatchAliasOrName(v)
+	})
+}
+
 // TableBlock represents the FROM clause of a SQL statement, including JOIN operations.
 type TableBlock struct {
-	Block
+	tableName tableName
+	items     joinItems
 }
 
 // NewTableBlock creates a new TableBlock with the specified table name.
 func NewTableBlock(table string) *TableBlock {
 	return &TableBlock{
-		Block: Block{delimiter: " ", content: table, values: make([]any, 0)},
+		tableName: *parseTableName(table),
+		items:     joinItems{},
 	}
 }
 
 // Build constructs the FROM clause string and returns it with placeholder values.
 func (b *TableBlock) Build() (string, []any) {
-	return b.content, []any{}
+	content := []string{b.tableName.String()}
+	joinContent, joinArgs := b.items.Build()
+	if joinContent != "" {
+		content = append(content, joinContent)
+	}
+	r := strings.Join(content, " ")
+	return r, joinArgs
+}
+
+func (b *TableBlock) add(joinType, table string, condition string, values ...any) {
+	tableName := parseTableName(table)
+	if b.items.MatchAliasOrName(tableName.AliasOrName()) {
+		// If the table is already included, skip adding it again
+		return
+	}
+	// Parse the table name and create a join item
+	item := &joinItem{
+		joinType:  joinType,
+		tableName: *tableName,
+		Condition: condition,
+		Args:      values,
+	}
+	b.items = append(b.items, item)
 }
 
 // InnerJoin adds an INNER JOIN clause to the table block.
 func (b *TableBlock) InnerJoin(table string, condition string, values ...any) {
-	b.Add("INNER JOIN "+table+" ON "+condition, values...)
+	b.add("INNER JOIN", table, condition, values...)
 }
 
 // LeftOuterJoin adds a LEFT OUTER JOIN clause to the table block.
 func (b *TableBlock) LeftOuterJoin(table string, condition string, values ...any) {
-	b.Add("LEFT OUTER JOIN "+table+" ON "+condition, values...)
+	b.add("LEFT OUTER JOIN", table, condition, values...)
 }

--- a/statement/table.go
+++ b/statement/table.go
@@ -12,6 +12,11 @@ func NewTableBlock(table string) *TableBlock {
 	}
 }
 
+// Build constructs the FROM clause string and returns it with placeholder values.
+func (b *TableBlock) Build() (string, []any) {
+	return b.content, []any{}
+}
+
 // InnerJoin adds an INNER JOIN clause to the table block.
 func (b *TableBlock) InnerJoin(table string, condition string, values ...any) {
 	b.Add("INNER JOIN "+table+" ON "+condition, values...)

--- a/statement/table_test.go
+++ b/statement/table_test.go
@@ -120,6 +120,50 @@ func TestTableBlock_InnerJoin(t *testing.T) {
 			wantValues:  []any{"active"},
 		},
 		{
+			name:    "INNER JOIN duplicated alias name",
+			initial: "orders o",
+			joins: []struct {
+				table     string
+				condition string
+				values    []any
+			}{
+				{
+					table:     "customers c",
+					condition: "o.customer_id = c.id AND c.status = ?",
+					values:    []any{"active"},
+				},
+				{
+					table:     "customers c",
+					condition: "o.customer_id = c.id AND c.status = ? AND c.value IS NULL", // This will be ignored
+					values:    []any{"inactive"},                                           // This will be ignored
+				},
+			},
+			wantContent: "orders o INNER JOIN customers c ON o.customer_id = c.id AND c.status = ?",
+			wantValues:  []any{"active"},
+		},
+		{
+			name:    "INNER JOIN duplicated table name",
+			initial: "orders",
+			joins: []struct {
+				table     string
+				condition string
+				values    []any
+			}{
+				{
+					table:     "customers",
+					condition: "orders.customer_id = customers.id AND customers.status = ?",
+					values:    []any{"active"},
+				},
+				{
+					table:     "customers",
+					condition: "orders.customer_id = customers.id AND customers.status = ? AND customers.value IS NULL", // This will be ignored
+					values:    []any{"inactive"},                                                                        // This will be ignored
+				},
+			},
+			wantContent: "orders INNER JOIN customers ON orders.customer_id = customers.id AND customers.status = ?",
+			wantValues:  []any{"active"},
+		},
+		{
 			name:    "Multiple INNER JOINs",
 			initial: "orders o",
 			joins: []struct {

--- a/statement/table_test.go
+++ b/statement/table_test.go
@@ -49,6 +49,20 @@ func TestNewTableBlock(t *testing.T) {
 			expectedAlias: "u",
 			expectedFrom:  "users AS u",
 		},
+		{
+			name:          "Create table block with unexpected spaces 1",
+			tableName:     "users `special users`",
+			expectedTable: "users",
+			expectedAlias: "`special users`",
+			expectedFrom:  "users `special users`",
+		},
+		{
+			name:          "Create table block with unexpected spaces 2",
+			tableName:     "`special users` users",
+			expectedTable: "`special",
+			expectedAlias: "users` users",
+			expectedFrom:  "`special users` users",
+		},
 	}
 
 	for _, tt := range tests {

--- a/statement/table_test.go
+++ b/statement/table_test.go
@@ -8,20 +8,46 @@ import (
 func TestNewTableBlock(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		tableName string
+		name          string
+		tableName     string
+		expectedTable string
+		expectedAlias string
+		expectedFrom  string
 	}{
 		{
-			name:      "Create table block with simple name",
-			tableName: "users",
+			name:          "Create table block with simple name",
+			tableName:     "users",
+			expectedTable: "users",
+			expectedAlias: "",
+			expectedFrom:  "users",
 		},
 		{
-			name:      "Create table block with schema",
-			tableName: "public.users",
+			name:          "Create table block with schema",
+			tableName:     "public.users",
+			expectedTable: "public.users",
+			expectedAlias: "",
+			expectedFrom:  "public.users",
 		},
 		{
-			name:      "Create table block with alias",
-			tableName: "users u",
+			name:          "Create table block with alias",
+			tableName:     "users u",
+			expectedTable: "users",
+			expectedAlias: "u",
+			expectedFrom:  "users u",
+		},
+		{
+			name:          "Create table block with AS alias",
+			tableName:     "users AS u",
+			expectedTable: "users",
+			expectedAlias: "u",
+			expectedFrom:  "users AS u",
+		},
+		{
+			name:          "Create table block with lower case AS alias",
+			tableName:     "users as u",
+			expectedTable: "users",
+			expectedAlias: "u",
+			expectedFrom:  "users AS u",
 		},
 	}
 
@@ -29,14 +55,18 @@ func TestNewTableBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tb := NewTableBlock(tt.tableName)
-			if tb.content != tt.tableName {
-				t.Errorf("NewTableBlock() content = %v, want %v", tb.content, tt.tableName)
+			if tb.tableName.Name != tt.expectedTable {
+				t.Errorf("NewTableBlock() table name = %v, want %v", tb.tableName.Name, tt.expectedTable)
 			}
-			if tb.delimiter != " " {
-				t.Errorf("NewTableBlock() delimiter = %v, want space", tb.delimiter)
+			if tb.tableName.Alias != tt.expectedAlias {
+				t.Errorf("NewTableBlock() alias = %v, want %v", tb.tableName.Alias, tt.expectedAlias)
 			}
-			if len(tb.values) != 0 {
-				t.Errorf("NewTableBlock() values = %v, want empty slice", tb.values)
+			r, args := tb.Build()
+			if r != tt.expectedFrom {
+				t.Errorf("NewTableBlock() content = %v, want %v", r, tt.expectedFrom)
+			}
+			if len(args) != 0 {
+				t.Errorf("NewTableBlock() values = %v, want empty slice", args)
 			}
 		})
 	}
@@ -142,11 +172,14 @@ func TestTableBlock_InnerJoin(t *testing.T) {
 			for _, join := range tt.joins {
 				tb.InnerJoin(join.table, join.condition, join.values...)
 			}
-			if tb.content != tt.wantContent {
-				t.Errorf("InnerJoin() content = %v, want %v", tb.content, tt.wantContent)
+			r, args := tb.Build()
+			if r != tt.wantContent {
+				t.Errorf("InnerJoin() content = %v, want %v", r, tt.wantContent)
 			}
-			if !reflect.DeepEqual(tb.values, tt.wantValues) {
-				t.Errorf("InnerJoin() values = %v, want %v", tb.values, tt.wantValues)
+			if len(args) != len(tt.wantValues) {
+				if !reflect.DeepEqual(args, tt.wantValues) {
+					t.Errorf("InnerJoin() values = %v, want %v", args, tt.wantValues)
+				}
 			}
 		})
 	}
@@ -230,11 +263,14 @@ func TestTableBlock_LeftOuterJoin(t *testing.T) {
 			for _, join := range tt.joins {
 				tb.LeftOuterJoin(join.table, join.condition, join.values...)
 			}
-			if tb.content != tt.wantContent {
-				t.Errorf("LeftOuterJoin() content = %v, want %v", tb.content, tt.wantContent)
+			r, args := tb.Build()
+			if r != tt.wantContent {
+				t.Errorf("LeftOuterJoin() content = %v, want %v", r, tt.wantContent)
 			}
-			if !reflect.DeepEqual(tb.values, tt.wantValues) {
-				t.Errorf("LeftOuterJoin() values = %v, want %v", tb.values, tt.wantValues)
+			if len(args) != len(tt.wantValues) {
+				if !reflect.DeepEqual(args, tt.wantValues) {
+					t.Errorf("LeftOuterJoin() values = %v, want %v", args, tt.wantValues)
+				}
 			}
 		})
 	}
@@ -256,10 +292,11 @@ func TestTableBlock_MixedJoins(t *testing.T) {
 	wantContent := "orders o INNER JOIN customers c ON o.customer_id = c.id LEFT OUTER JOIN order_discounts d ON o.id = d.order_id AND d.active = ? INNER JOIN products p ON o.product_id = p.id AND p.available = ?"
 	wantValues := []any{true, true}
 
-	if tb.content != wantContent {
-		t.Errorf("Mixed joins content = %v, want %v", tb.content, wantContent)
+	r, args := tb.Build()
+	if r != wantContent {
+		t.Errorf("Mixed joins content = %v, want %v", r, wantContent)
 	}
-	if !reflect.DeepEqual(tb.values, wantValues) {
-		t.Errorf("Mixed joins values = %v, want %v", tb.values, wantValues)
+	if !reflect.DeepEqual(args, wantValues) {
+		t.Errorf("Mixed joins values = %v, want %v", args, wantValues)
 	}
 }

--- a/tests/mysql/queries/books_with_inner_join/condition.go
+++ b/tests/mysql/queries/books_with_inner_join/condition.go
@@ -3,7 +3,6 @@ package bookswithinnerjoin
 import (
 	"github.com/tecowl/querybm"
 	. "github.com/tecowl/querybm/expr"
-	"github.com/tecowl/querybm/helpers"
 )
 
 type Condition struct {
@@ -14,9 +13,7 @@ var _ querybm.Condition = (*Condition)(nil)
 
 func (c *Condition) Build(s *querybm.Statement) {
 	if c.AuthorName != "" {
-		s.Table.InnerJoin("authors", "books.author_id = authors.author_id")
+		addAuthorsJoin(s)
 		s.Where.Add(Field("authors.name", LikeContains(c.AuthorName)))
-	} else if !helpers.IsCountOnly(s.Fields.Fields()) {
-		s.Table.InnerJoin("authors", "books.author_id = authors.author_id")
 	}
 }

--- a/tests/mysql/queries/books_with_inner_join/query.go
+++ b/tests/mysql/queries/books_with_inner_join/query.go
@@ -6,14 +6,16 @@ import (
 	"github.com/tecowl/querybm"
 )
 
+func addAuthorsJoin(s *querybm.Statement) {
+	s.Table.InnerJoin("authors", "books.author_id = authors.author_id")
+}
+
 var columns querybm.FieldMapper[Book] = querybm.NewFields(
 	[]string{"book_id", "authors.author_id", "authors.name", "isbn", "book_type", "title", "yr", "available", "tags"},
 	func(rows querybm.Scanner, book *Book) error {
 		return rows.Scan(&book.BookID, &book.AuthorID, &book.AuthorName, &book.Isbn, &book.BookType, &book.Title, &book.Yr, &book.Available, &book.Tags)
 	},
-	func(s *querybm.Statement) {
-		s.Table.InnerJoin("authors", "books.author_id = authors.author_id")
-	},
+	addAuthorsJoin,
 )
 
 var sort = querybm.NewSortItem("title", false)

--- a/tests/mysql/queries/books_with_inner_join/query.go
+++ b/tests/mysql/queries/books_with_inner_join/query.go
@@ -11,6 +11,9 @@ var columns querybm.FieldMapper[Book] = querybm.NewFields(
 	func(rows querybm.Scanner, book *Book) error {
 		return rows.Scan(&book.BookID, &book.AuthorID, &book.AuthorName, &book.Isbn, &book.BookType, &book.Title, &book.Yr, &book.Available, &book.Tags)
 	},
+	func(s *querybm.Statement) {
+		s.Table.InnerJoin("authors", "books.author_id = authors.author_id")
+	},
 )
 
 var sort = querybm.NewSortItem("title", false)


### PR DESCRIPTION
TableBlocks methods for JOIN should be called by fields definition which contains column names of joined table.
So this PR make Query calls Fields.Build if the Fields implements Builder interface for JOIN.

## When JOIN is required in tests/mysql/queries/books_with_inner_join

Condition | SELECT ... FROM ... | SELECT COUNT(*) FROM ...
-----|--------------------|-----------------------
AuthorName is empty |  REQUIRED | not required
AuthorName is not empty | REQUIRED | REQUIRED

## Duplicated table name for JOIN

If either AddInnerJoin or AddLeftOuterJoin is called twice with duplicated alias (or table name without alias), the 2nd invocation is ignored.
So it's OK if your Fields and Condition call it for the same JOIN. You should use different alias name for each join if you call it for different JOIN with the same alias (or table name without alias).

